### PR TITLE
Add useRequestHandler method to inject middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ router.get('/secretRoute', {description: 'Nobody here but us chickens.', hide: t
 });
 ```
 
+Add middleware to intercept requests before routing to docs:
+```js
+var docs = require('koa-resourcer-docs');
+
+// Respond with 404 if not in a development environment
+docs.useRequestHandler(function* (next) {
+  if (process.env.NODE_ENV === 'development') {
+    return yield next;
+  }
+  this.throw(404);
+});
+```
+
 ## Installation
 ```
 npm install koa-resourcer-docs --save

--- a/docs.js
+++ b/docs.js
@@ -9,6 +9,9 @@ var router = require('koa-joi-router');
 var docs = module.exports = koa();
 var r = router();
 
+// If defined, custom middleware called by interceptRequest()
+var requestHandler;
+
 // holds the routes as they are added by koa-resourcer
 var routes = [];
 
@@ -32,6 +35,7 @@ r.get('/index.json'
 , {
     description: 'API documentation in JSON format.'
   }
+, interceptRequest
 , function* () {
     if (objCache) {
       this.body = objCache;
@@ -50,6 +54,7 @@ r.get('/'
 , {
     description: 'API documentation in human-readable HTML format.'
   }
+, interceptRequest
 , function* () {
     if (htmlCache) {
       this.body = htmlCache;
@@ -86,6 +91,28 @@ docs.clearCache = function clearCache() {
   htmlCache = null;
   objCache = null;
 };
+
+/**
+ * Override request handling middleware
+ * @api public
+ */
+
+docs.useRequestHandler = function useRequestHandler(handler) {
+  requestHandler = handler;
+};
+
+/**
+ * Middleware to intercept the request and allow a custom handler.
+ * @api private
+ */
+
+function* interceptRequest(next) {
+  if (typeof requestHandler === 'function') {
+    return yield requestHandler.call(this, next);
+  } else {
+    return yield next;
+  }
+}
 
 /**
  * Load the documentation template.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-resourcer-docs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Simple route documentation for koa-resourcer.",
   "main": "docs.js",

--- a/test/docsSpec.js
+++ b/test/docsSpec.js
@@ -118,8 +118,18 @@ describe('koa-resourcer-docs', function() {
 
     describe('GET', function () {
       var docsObj;
+      it('should call the optional request handler middleware if set', function* () {
+        var requestHandled = false;
+        docs.useRequestHandler(function* (next) {
+          requestHandled = true;
+          return yield next;
+        });
+        yield test(app).get('/docs').expect(200).end();
+        assert(requestHandled, "Request handler not called.");
+        // Reset the request handler to default behavior
+        docs.useRequestHandler();
+      });
       it('responds with an object containing a docs property', function* () {
-        docs.clearCache();
         var res = yield test(app).get('/docs/index.json').expect(200).end();
 
         assert(Array.isArray(res.body.docs));


### PR DESCRIPTION
### Introduction

A common use case for middleware is to "gate" access to a route.  This is now being added to `koa-resourcer-docs` to allow more control over the documentation routes.
### Use

Simply add koa middleware using the new `useRequestHandler` method on the koa-resourcer-docs object.  See the README.md modification in this pull request for more details.

Reviewers: @aheckmann @jlai 
