### PR TITLE
Fixed issue when a validate attribute is undefined, o.describe throws

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -179,10 +179,11 @@ function describeRoute(route) {
  */
 
 function describeObject(o) {
+  if (!isObject(o)) return o;
+
   if (typeof o.describe === 'function') return o.describe();
 
   var ret = {};
-  if (!isObject(o)) return o;
 
   Object.keys(o).forEach(function(key) {
     ret[key] = describeObject(o[key]);

--- a/test/docsSpec.js
+++ b/test/docsSpec.js
@@ -115,6 +115,10 @@ describe('koa-resourcer-docs', function() {
         assert(html.indexOf('Overridden') === -1);
         assert(html.indexOf('commanding') > 0);
       });
+
+      it('should not throw when a validate attribute is undefined', function* () {
+        assert(html.indexOf('/badvalidate') > 0);
+      });
     });
   });
 

--- a/test/docsSpec.js
+++ b/test/docsSpec.js
@@ -117,7 +117,7 @@ describe('koa-resourcer-docs', function() {
       });
 
       it('should not throw when a validate attribute is undefined', function* () {
-        assert(html.indexOf('/badvalidate') > 0);
+        assert(html.indexOf('/undefinedValidateProp') > 0);
       });
     });
   });

--- a/test/resources/router/partial/partial.js
+++ b/test/resources/router/partial/partial.js
@@ -25,6 +25,20 @@ r.get('/visible',
   }
 );
 
+r.get('/badvalidate',
+  {
+    meta: {
+      description: 'Route with an undefined validate attribute'
+    },
+    validate: {
+      body: undefined
+    }
+  },
+  function* () {
+    this.body = 'This should not throw an error!';
+  }
+);
+
 r.get('/hidden',
   {
     meta: {

--- a/test/resources/router/partial/partial.js
+++ b/test/resources/router/partial/partial.js
@@ -25,7 +25,7 @@ r.get('/visible',
   }
 );
 
-r.get('/badvalidate',
+r.get('/undefinedValidateProp',
   {
     meta: {
       description: 'Route with an undefined validate attribute'


### PR DESCRIPTION
When a parameter in the validate object has a value of undefined, it would call describeObject(undefined) and then o.describe would throw.